### PR TITLE
Fixed typo in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ version: '3'
 services:
   cync-lan:
     container_name: cync-lan
-    image: baudneo/cync_lan:latest
+    image: baudneo/cync-lan:latest
     restart: unless-stopped
 #    build:
 #      dockerfile: ./Dockerfile


### PR DESCRIPTION
Docker compose was pulling down nonexistent "cync_lan" repo from Docker Hub instead of "cync-lan"