### PR TITLE
fix: move assignment out of condition

### DIFF
--- a/src/cync-lan.py
+++ b/src/cync-lan.py
@@ -2289,8 +2289,8 @@ class CyncHTTPDevice:
                         # there is no gurantee the version is sent before checking the timestamp, so use a gross hack.
                         if self.version and (self.version >= 30000 <= 40000):
                             ts_end_idx = -2
-                            ts = packet_data[ts_idx:ts_end_idx]
 
+                        ts = packet_data[ts_idx:ts_end_idx]
                         ts_ascii = ts.decode("ascii", errors="replace")
                         # gross hack
                         if ts_ascii[-1] != ',':


### PR DESCRIPTION
In the latest refactor, the assignment seems to have been accidentally moved into a `if` condition. Therefore, in some cases, `ts` is never assigned.

Btw, thanks for your work. I started using it today with 2 new Outdoor Smart Bulbs (PAR38) that I purchased. I'm very happy to have a way to control them locally with Home Assistant.