### PR TITLE
change fan speed presets to use percentage

### DIFF
--- a/src/cync_lan/devices.py
+++ b/src/cync_lan/devices.py
@@ -432,12 +432,8 @@ class CyncNode:
         """
         lp = f"{self.lp}set_brightness:"
         if bri < 0 or bri > 100:
-            if self.is_fan_controller:
-                # fan can be controlled via light control structs: brightness -> max=255, high=191, medium=128, low=50, off=0
-                pass
-            elif self.is_light or self.is_switch:
-                logger.error(f"{lp} Invalid brightness: {bri} must be 0-100")
-                return
+            logger.error(f"{lp} Invalid brightness: {bri} must be 0-100")
+            return
 
         # elif bri == self._brightness:
         #     logger.debug(f"{lp} Device already in brightness {bri}, skipping...")

--- a/src/cync_lan/devices.py
+++ b/src/cync_lan/devices.py
@@ -401,13 +401,13 @@ class CyncNode:
             if speed == FanSpeed.OFF:
                 await self.set_brightness(0)
             elif speed == FanSpeed.LOW:
-                await self.set_brightness(50)
+                await self.set_brightness(25)
             elif speed == FanSpeed.MEDIUM:
-                await self.set_brightness(128)
+                await self.set_brightness(50)
             elif speed == FanSpeed.HIGH:
-                await self.set_brightness(191)
+                await self.set_brightness(75)
             elif speed == FanSpeed.MAX:
-                await self.set_brightness(255)
+                await self.set_brightness(100)
             else:
                 logger.error(
                     f"{self.lp} Invalid fan speed: {speed}, must be one of {list(FanSpeed)}"
@@ -423,7 +423,7 @@ class CyncNode:
 
     async def set_brightness(self, bri: int, sub_id: Optional[int] = None):
         """
-        Send raw data to control device brightness (0-100). Fans are 0-255.
+        Send raw data to control device brightness (0-100). Fans are also 0-100.
         """
         """
         73 00 00 00 22 37 96 24 69 60 48 00 7e 17 00 00  s..."7.$i`H.~...

--- a/src/cync_lan/mqtt_client.py
+++ b/src/cync_lan/mqtt_client.py
@@ -285,22 +285,22 @@ class MQTTClient:
                                     logger.debug(
                                         f"{lp} Fan percentage received: {percentage}, translated to: 'low' preset"
                                     )
-                                    tasks.append(node.set_brightness(50))
+                                    tasks.append(node.set_brightness(25))
                                 elif percentage <= 50:
                                     logger.debug(
                                         f"{lp} Fan percentage received: {percentage}, translated to: 'medium' preset"
                                     )
-                                    tasks.append(node.set_brightness(128))
+                                    tasks.append(node.set_brightness(50))
                                 elif percentage <= 75:
                                     logger.debug(
                                         f"{lp} Fan percentage received: {percentage}, translated to: 'high' preset"
                                     )
-                                    tasks.append(node.set_brightness(191))
+                                    tasks.append(node.set_brightness(75))
                                 elif percentage <= 100:
                                     logger.debug(
                                         f"{lp} Fan percentage received: {percentage}, translated to: 'max' preset"
                                     )
-                                    tasks.append(node.set_brightness(255))
+                                    tasks.append(node.set_brightness(100))
                                 else:
                                     logger.warning(
                                         f"{lp} Fan percentage received: {percentage} is out of range (0-100), skipping..."
@@ -744,7 +744,7 @@ class MQTTClient:
 
         elif dev_type == "fan":
             registry_struct["platform"] = "fan"
-            # fan can be controlled via light control structs: brightness -> max=255, high=191, medium=128, low=50, off=0
+            # fan can be controlled via light control structs: brightness -> max=100, high=75, medium=50, low=25, off=0
             registry_struct["percentage_command_topic"] = (
                 "{0}/set/{1}/percentage".format(self.topic, entity_uuid)
             )


### PR DESCRIPTION
Fixes #21

Change preset values to use percentages 0-100 instead of 0-255.

Tested on a real device, all 4 speeds reflect on the device.