### PR TITLE
add device 151, soft white decorative candle light

### DIFF
--- a/src/cync_lan/metadata/model_info.py
+++ b/src/cync_lan/metadata/model_info.py
@@ -645,6 +645,14 @@ device_type_map = {
         characteristics=LightCharacteristics(min_kelvin=2700),
         capabilities=LightCapabilities(),
     ),
+    151: DeviceTypeInfo(
+        type=DeviceClassification.LIGHT,
+        model_name="Soft White Decorative Candle Light",
+        model_id="CLEDBM6LDGF",
+        protocol=DeviceProtocol(TCP=True),
+        characteristics=LightCharacteristics(lumens=500, min_kelvin=2700, cri=90),
+        capabilities=LightCapabilities(),
+    ),
     152: DeviceTypeInfo(
         type=DeviceClassification.LIGHT,
         model_name="Reveal HD+ White A19 Bulb",


### PR DESCRIPTION
I haven't been able to test - my debug addon for cync lan got nuked recently, but I can't see much that would go wrong here.

Device page is here for reference:
https://www.gelighting.com/led-lights/bulbs/medium-base/ge-cync-smart-led-light-bulb-soft-white-decorative-candle-light-works