### PR TITLE
fix(mqtt): reflect device-reported fan speed in HA (publish percentage/preset from status) — fixes #35

### DIFF
--- a/src/cync_lan/mqtt_client.py
+++ b/src/cync_lan/mqtt_client.py
@@ -796,7 +796,42 @@ class MQTTClient:
             "state": power_status
         }
 
-        if node.is_plug or node.is_switch:
+        if node.is_fan_controller:
+            # A fan controller is also an is_switch, so it MUST be handled before the
+            # generic switch branch below. The generic branch only publishes ON/OFF and
+            # drops the device-reported speed, so physical/external speed changes never
+            # reach HA. Mirror the percentage/preset publishing done by
+            # update_fan_speed/update_fan_percent, but sourced from the device status.
+            perc = entity.brightness if entity.brightness is not None else 0
+            perc = max(0, min(100, perc))
+            # Bucket to a FanSpeed preset using the SAME thresholds as _queue_fan_extra.
+            if perc == 0:
+                speed = FanSpeed.OFF
+            elif perc <= 25:
+                speed = FanSpeed.LOW
+            elif perc <= 50:
+                speed = FanSpeed.MEDIUM
+            elif perc <= 75:
+                speed = FanSpeed.HIGH
+            else:
+                speed = FanSpeed.MAX
+            await self.pub_entity_state(
+                node,
+                str(perc).encode(),
+                0,
+                from_pkt=from_pkt,
+                tpc=f"{self.topic}/status/{node.hass_id}/percentage",
+            )
+            await self.pub_entity_state(
+                node,
+                speed.encode(),
+                0,
+                from_pkt=from_pkt,
+                tpc=f"{self.topic}/status/{node.hass_id}/preset",
+            )
+            mqtt_dev_state = power_status.encode()
+
+        elif node.is_plug or node.is_switch:
             mqtt_dev_state = power_status.encode()
 
         else:


### PR DESCRIPTION
## What

In `parse_entity_state` (`src/cync_lan/mqtt_client.py`), handle fan controllers **before** the generic plug/switch branch, and publish the device-reported speed to the fan's `percentage` and `preset` MQTT topics.

## Why

A fan controller is classified as a switch (`is_fan_controller` only ever returns true for `DeviceClassification.SWITCH` devices that also have the fan capability), so it currently falls into the generic `if node.is_plug or node.is_switch:` branch, which sets `mqtt_dev_state = power_status.encode()` — i.e. **ON/OFF only**. The speed the device reports (carried in `entity.brightness`) is dropped on the floor.

Today the `percentage`/`preset` topics are written **only** by `update_fan_speed` / `update_fan_percent`, which fire on *commands originating from HA*. Nothing writes those topics from an inbound device status. The result: when a fan's speed is changed **physically at the wall control or by any other app/automation**, Home Assistant never sees the new speed — the entity stays stuck at whatever HA last commanded.

## The fix

Add an `if node.is_fan_controller:` branch immediately before the plug/switch branch (order matters — a fan is also `is_switch`, so it has to be caught first). In that branch:

- Read the reported percent from `entity.brightness` (default 0), clamp to `0..100`.
- Bucket it to a `FanSpeed` preset using the **exact same thresholds** as `_queue_fan_extra` (0 → off, ≤25 → low, ≤50 → medium, ≤75 → high, else → max).
- Publish `str(perc)` to the `.../percentage` topic and the preset to the `.../preset` topic, using the **same `pub_entity_state` mechanism and identical topic construction** that `update_fan_speed` uses — with `from_pkt` threaded through so the log line still attributes the source packet. (`update_fan_speed` itself doesn't take `from_pkt`, so I call the shared `pub_entity_state` directly — same mechanism, same topics, same payload encoding.)
- Still set `mqtt_dev_state = power_status.encode()` so the ON/OFF state payload is published exactly as before by the existing trailing `pub_entity_state` call.

The old `if node.is_plug or node.is_switch:` becomes `elif`, so non-fan switches/plugs are completely unchanged.

## Why `entity.brightness` is the right source

The 0x83 device-status decode unpacks the brightness byte straight into `EntityState.brightness` (`devices.py`), and on the command side `set_fan_speed` / `set_fan_percentage` transmit the speed via `set_brightness`. The fan discovery config even documents it: `brightness -> max=100, high=75, medium=50, low=25, off=0`. So `entity.brightness` is exactly where the device-reported fan speed lands by the time `parse_entity_state` runs.

## Scope / safety

- Only the fan-controller path changes. Plugs, switches, bulbs, and RGB/CCT paths are untouched (the switch line just becomes `elif`, and the bulb `else` is preserved verbatim).
- No double-publish and nothing dropped: three distinct topics are written — `.../percentage`, `.../preset`, and the fan's main state topic `{topic}/status/{hass_id}` via the unchanged trailing `pub_entity_state` call.
- No new imports: `FanSpeed`, `pub_entity_state`, `self.topic`, `node.hass_id` are all already used in this file.
- Bucket thresholds and topic strings were copied verbatim from the existing `_queue_fan_extra` and `update_fan_speed` code so command-side and status-side stay consistent.

## Honesty / testing

I do **not** own a Cync fan-controller device, so this is **untested on real hardware**. I've confirmed it compiles, that the branch structure is correct (`if is_fan_controller` → `elif is_plug/is_switch` → existing bulb `else`), and that it reuses the exact existing publish mechanism, `FanSpeed` members, topic strings, and `_queue_fan_extra` buckets against the current `python` branch. What still needs a real device is the physical round-trip: change the speed at the wall and confirm HA updates.

@tobyroworth — since you have the hardware and reported this, could you verify before merge? The one thing I'd most want confirmed is that a physical speed change actually shows up in HA (percentage + preset), and that the reported percent values fall in the expected 0–100 range. Happy to adjust the branch placement or the percent-source field if the device reports speed somewhere other than `entity.brightness`.

Fixes #35.